### PR TITLE
Prevent monthly repeat visits in provision flow

### DIFF
--- a/MANUAL_TEST_PLAN.md
+++ b/MANUAL_TEST_PLAN.md
@@ -1,0 +1,24 @@
+# Manual Test Plan: Monthly Visit Restriction
+
+## Purpose
+Confirm that customers cannot be processed more than once per month in `provision` flow.
+
+## Preconditions
+- At least one customer exists in Firestore `customers` collection.
+- Customer has no visit recorded for the current month under the current fiscal year period key.
+
+## Test Steps
+1. **First Visit**
+   1. Open `provision.html` in the browser and log in.
+   2. Enter the customer's ID or name and click `lookup`.
+   3. Verify the customer's information is shown and product selection section becomes visible.
+   4. Select products totaling ≤30 points and submit.
+   5. Observe a success toast and confirm the visit date is written to `visits[periodKey]`.
+2. **Second Visit (same month)**
+   1. Without altering Firestore, attempt another lookup for the same customer.
+   2. Confirm a toast appears saying `이미 방문한 대상자입니다`.
+   3. Ensure the product selection section remains hidden and submission is not possible.
+
+## Expected Result
+- First visit is logged normally.
+- Any subsequent visit attempts within the same month display the warning toast and block product selection.

--- a/js/provision.js
+++ b/js/provision.js
@@ -58,15 +58,29 @@ lookupBtn.addEventListener("click", async () => {
       return showToast("해당 이용자를 찾을 수 없습니다.", true);
     } else if (matches.length === 1) {
       selectedCustomer = { id: matches[0].id, ...matches[0].data() };
+
+      const now = new Date();
+      const currentMonth = now.toISOString().slice(0, 7);
+      const year =
+        now.getMonth() + 1 < 3 ? now.getFullYear() - 1 : now.getFullYear();
+      const periodKey = `${String(year).slice(2)}-${String(year + 1).slice(2)}`;
+      const alreadyVisited = selectedCustomer.visits?.[periodKey]?.some((v) =>
+        v.startsWith(currentMonth)
+      );
+
       renderCustomerInfo();
-      productSection.classList.remove("hidden");
-      submitSection.classList.remove("hidden");
+
+      if (alreadyVisited) {
+        showToast("이미 방문한 대상자입니다", true);
+        productSection.classList.add("hidden");
+        submitSection.classList.add("hidden");
+      } else {
+        productSection.classList.remove("hidden");
+        submitSection.classList.remove("hidden");
+      }
     } else {
       showDuplicateSelection(matches);
     }
-
-    productSection.classList.remove("hidden");
-    submitSection.classList.remove("hidden");
   } catch (err) {
     console.error(err);
     showToast("이용자 조회 중 오류 발생", true);
@@ -150,10 +164,27 @@ document.getElementById("confirm-duplicate").addEventListener("click", () => {
   if (!selectedCandidate) return showToast("이용자를 선택하세요.", true);
 
   selectedCustomer = selectedCandidate;
+
+  const now = new Date();
+  const currentMonth = now.toISOString().slice(0, 7);
+  const year =
+    now.getMonth() + 1 < 3 ? now.getFullYear() - 1 : now.getFullYear();
+  const periodKey = `${String(year).slice(2)}-${String(year + 1).slice(2)}`;
+  const alreadyVisited = selectedCustomer.visits?.[periodKey]?.some((v) =>
+    v.startsWith(currentMonth)
+  );
+
   renderCustomerInfo();
   duplicateModal.classList.add("hidden");
-  productSection.classList.remove("hidden");
-  submitSection.classList.remove("hidden");
+
+  if (alreadyVisited) {
+    showToast("이미 방문한 대상자입니다", true);
+    productSection.classList.add("hidden");
+    submitSection.classList.add("hidden");
+  } else {
+    productSection.classList.remove("hidden");
+    submitSection.classList.remove("hidden");
+  }
 });
 
 async function loadAllProductsOnce() {


### PR DESCRIPTION
## Summary
- warn and hide product section if customer already visited this month
- apply same monthly visit check after resolving duplicate customers
- add manual test plan for blocking repeat monthly visits

## Testing
- `node --check js/provision.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689952d5b600832db29241a4cd67f21f