### PR TITLE
Improve responsive layouts

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -223,8 +223,8 @@ main {
   background-color: white;
   padding: 16px 20px;
   border-radius: 12px;
-  width: 360px;
-  max-width: 90%;
+  width: 90%;
+  max-width: 400px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
   box-sizing: border-box;
 }

--- a/css/customers.css
+++ b/css/customers.css
@@ -62,8 +62,8 @@
 }
 
 #customer-table {
-  min-width: 100%;
-  width: 1300px;
+  width: 100%;
+  min-width: 800px;
   border-collapse: collapse;
   table-layout: auto;
 }
@@ -193,6 +193,17 @@ td {
   #open-modal-btn {
     align-self: flex-end;
   }
+
+  #customer-table th:nth-child(6),
+  #customer-table td:nth-child(6),
+  #customer-table th:nth-child(7),
+  #customer-table td:nth-child(7),
+  #customer-table th:nth-child(8),
+  #customer-table td:nth-child(8),
+  #customer-table th:nth-child(9),
+  #customer-table td:nth-child(9) {
+    display: none;
+  }
 }
 
 /* 모바일 (폰) */
@@ -212,5 +223,12 @@ td {
 
   #pagination {
     font-size: 14px;
+  }
+
+  #customer-table th:nth-child(3),
+  #customer-table td:nth-child(3),
+  #customer-table th:nth-child(4),
+  #customer-table td:nth-child(4) {
+    display: none;
   }
 }

--- a/css/provision.css
+++ b/css/provision.css
@@ -137,8 +137,13 @@
   position: relative;
 }
 
+.selected-products {
+  overflow-x: auto;
+}
+
 #selected-table {
   width: 100%;
+  min-width: 600px;
   border-collapse: collapse;
   margin-top: 10px;
   font-size: 0.95rem;
@@ -152,7 +157,7 @@
 /* 수량 열 td 자체에 너비 제한 */
 #selected-table td:nth-child(2),
 #selected-table th:nth-child(2) {
-  width: 110px; /* 또는 100px, 조절 가능 */
+  min-width: 80px;
   text-align: center;
 }
 
@@ -204,11 +209,12 @@
   border: 1px solid #ccc;
   padding: 8px 10px;
   text-align: center;
-  total-summary {
-    margin-top: 1rem;
-    font-weight: bold;
-    font-size: 1.1rem;
-  }
+}
+
+#total-summary {
+  margin-top: 1rem;
+  font-weight: bold;
+  font-size: 1.1rem;
 }
 
 #product-action-buttons button {
@@ -300,4 +306,24 @@ button:disabled {
 
 .hidden {
   display: none;
+}
+
+@media (max-width: 768px) {
+  #selected-table th:nth-child(3),
+  #selected-table td:nth-child(3),
+  #selected-table th:nth-child(4),
+  #selected-table td:nth-child(4) {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .product-input-area {
+    flex-direction: column;
+  }
+
+  #selected-table th:nth-child(5),
+  #selected-table td:nth-child(5) {
+    display: none;
+  }
 }

--- a/customers.html
+++ b/customers.html
@@ -30,7 +30,7 @@
 
       <main class="container">
         <h2>이용자 조회</h2>
-        <div class="top-bar">
+        <div id="top-bar">
           <div class="search-bar">
             <input id="global-search" placeholder="전체 검색 (이름, 주소 등)" />
 

--- a/provision.html
+++ b/provision.html
@@ -78,7 +78,7 @@
             </button>
           </div>
 
-          <div class="selected-products">
+          <div class="selected-products table-wrapper">
             <table id="selected-table">
               <thead>
                 <tr>


### PR DESCRIPTION
## Summary
- Replace fixed modal width with flexible sizing in common styles
- Make customer and provision tables responsive, hiding columns on tablet and mobile
- Wrap provision table in overflow container for graceful small-screen behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689952df23ec832d8d97aa31cba1c89e